### PR TITLE
Fix nullpointer on open ended timeframes with new generated codes

### DIFF
--- a/languages/commonsbooking-de_DE.po
+++ b/languages/commonsbooking-de_DE.po
@@ -1406,8 +1406,8 @@ msgid "Location Category"
 msgstr "Standort-Kategorie"
 
 #: src/Repository/BookingCodes.php:296
-msgid "No booking codes could be created because there were no booking codes to choose from. Please set some booking codes in the CommonsBooking settings."
-msgstr "Es konnten keine Buchungscodes erstellt werden, da keine Buchungscodes zur Auswahl standen. Bitte lege einige Buchungscodes in den CommonsBooking-Einstellungen fest."
+msgid "No booking codes could be created for this timeframe, because no initial booking codes were defined in the CommonsBooking settings."
+msgstr "Es konnten keine Buchungscodes erstellt werden, da noch keine initiale Erstellung in den CommonsBooking-Einstellungen vorgenommen wurde."
 
 #: src/Repository/BookingCodes.php:302
 msgid "No booking codes could be created because the location of the timeframe could not be found."

--- a/languages/commonsbooking.pot
+++ b/languages/commonsbooking.pot
@@ -1370,7 +1370,7 @@ msgid "CommonsBooking Bookings"
 msgstr ""
 
 #: src/Repository/BookingCodes.php:296
-msgid "No booking codes could be created because there were no booking codes to choose from. Please set some booking codes in the CommonsBooking settings."
+msgid "No booking codes could be created for this timeframe, because no initial booking codes were defined in the CommonsBooking settings."
 msgstr ""
 
 #: src/Repository/BookingCodes.php:302

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -291,7 +291,7 @@ class BookingCodes {
 
 		$bookingCodesArray = static::getCodesArray();
 		if (! $bookingCodesArray ){
-			throw new BookingCodeException( __( "No booking codes could be created because there were no booking codes to choose from. Please set some booking codes in the CommonsBooking settings.", 'commonsbooking' )  );
+			throw new BookingCodeException( __( "No booking codes could be created for this timeframe, because no initial booking codes were defined in the CommonsBooking settings.", 'commonsbooking' )  );
 		}
 		// Before we add new codes, we remove old ones, that are not relevant anymore
 		try {

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -74,8 +74,8 @@ class BookingCodes {
 			//check, if we have enough codes for the timeframe or if we need to generate more
 			//we only need to check, if we have an open-ended timeframe
 			//we check, if the end date of the last generated code is before the end date of the requested time period
-			if ( ! $timeframe->getRawEndDate() &&
-			     strtotime(self::getLastCode($timeframe)->getDate()) < strtotime($endDate)
+			if ( ! $timeframe->getRawEndDate() && self::getLastCode( $timeframe ) &&
+			     strtotime( self::getLastCode( $timeframe )->getDate() ) < strtotime( $endDate )
 			) {
 				$startGenerationPeriod = new \DateTime( self::getLastCode($timeframe)->getDate() );
 				$endGenerationPeriod = new \DateTime( $endDate );


### PR DESCRIPTION
Konnte die Changes nicht direkt auf den Branch bei @printpagestopdf pushen, daher der Umweg hier.

Bei mir trat ein NullPointer auf wenn ich für ein Timeframe mit offenem Ende versucht habe die Booking-Codes zu generieren. (Booking-Codes habe ich kurz vorher im Backend eingetragen).